### PR TITLE
Fix default for apiServiceURL proxying.

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -6,13 +6,6 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "kubeapps.parseAPIServiceURL" -}}
-{{- $parsed := urlParse . }}
-{{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
-{{- $path := get $parsed "path" }}
-{{ dict "baseURL" $baseURL "path" $path | toYaml }}
-{{- end -}}
-
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -62,9 +62,11 @@ data:
     {{/* We need to split the API service URL(s) into the base url and the path segment so
            those configurations using a path can be appropriately rewritten below while
            ensuring the proxy_pass statement is given the base URL only. */}}
-    {{- $apiServiceURLMap := include "kubeapps.parseAPIServiceURL" .apiServiceURL | fromYaml }}
-        rewrite /api/clusters/{{ .name }}/(.*) {{ $apiServiceURLMap.path }}/$1 break;
-        rewrite /api/clusters/{{ .name }} {{ $apiServiceURLMap.path }}/ break;
+    {{- $parsed := urlParse (default "" .apiServiceURL) }}
+    {{- $apiServiceBaseURL := ternary "" (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) (empty .apiServiceURL)}}
+    {{- $apiServiceURLPath := get $parsed "path" }}
+        rewrite /api/clusters/{{ .name }}/(.*) {{ $apiServiceURLPath }}/$1 break;
+        rewrite /api/clusters/{{ .name }} {{ $apiServiceURLPath }}/ break;
 
     {{/* Helm returns a nil pointer error when accessing foo.bar if foo doesn't
            exist, even with the `default` function.
@@ -83,7 +85,7 @@ data:
         proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
-        proxy_pass {{ $apiServiceURLMap.baseURL }};
+        proxy_pass {{ default "https://kubernetes.default" $apiServiceBaseURL }};
     {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
     {{- end }}


### PR DESCRIPTION

### Description of the change

Uses existing default for api service URL while maintaining Matt's changes in #2337 . Also removes the helper which I'd pushed for when forgetting that helpers can only return strings.

### Benefits

Template renders when an `.apiServiceURL` isn't defined (ie. assumed default).
